### PR TITLE
Apply GitHub-style dark theme

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Header from './components/Header';
 import Curriculo from './components/Curriculo';
 import SobreMim from './components/SobreMim';
@@ -9,12 +9,16 @@ import Contato from './components/Contato';
 const AppContainer = styled.div`
   width: 100vw;
   min-height: 100vh;
-  background-image: linear-gradient(90deg, #222831, #393e46);
+  background-image: linear-gradient(90deg, #0d1117, #161b22);
 `;
 
 
 function App() {
-  const [activeSection, setActiveSection] = useState(null);
+  const [activeSection, setActiveSection] = useState('curriculo');
+
+  useEffect(() => {
+    window.location.hash = 'curriculo';
+  }, []);
 
   return (
     <AppContainer>

--- a/src/components/Curriculo/index.js
+++ b/src/components/Curriculo/index.js
@@ -20,6 +20,7 @@ export default function Curriculo() {
       <Paragraph><strong>Objetivo:</strong> Desenvolvedor especializado em C#, aplicando boas práticas, design patterns e arquitetura de software para soluções escaláveis.</Paragraph>
       <Paragraph><strong>Resumo:</strong> Desenvolvedor fullstack com experiência em C#, PHP, JavaScript, MySQL e SQL Server. Foco atual exclusivo em C#, desenvolvimento backend e arquitetura de software.</Paragraph>
       <Paragraph><strong>Formação:</strong> Ciências da Computação - Estácio de Sá (2017 - 2024)</Paragraph>
+      <Paragraph><strong>Idiomas:</strong> Inglês avançado com diploma na Cultura Inglesa.</Paragraph>
       <Paragraph><strong>Experiência:</strong></Paragraph>
       <ul>
         <li>Onclick (Estagiário, 2022 - 2024) - Desenvolvimento e manutenção de aplicações web, integração com bancos SQL e suporte a ERPs.</li>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -3,7 +3,7 @@ import OptionsHeader from "../OptionsHeader";
 import IconsHeader from "../IconsHeader";
 
 const HeaderContainer = styled.header`
-    background-color: #FFF;
+    background-color: #0d1117;
     display: flex;
     justify-content: center;
 `;

--- a/src/components/OptionsHeader/index.js
+++ b/src/components/OptionsHeader/index.js
@@ -6,6 +6,7 @@ const Options = styled.ul`
 
 const Option = styled.li`
     font-size: 16px;
+    color: #c9d1d9;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -26,7 +27,7 @@ const Link = styled.a`
     height: 150%;
     
     &:hover {
-        background-color: #f0f0f0; /* Adapte a cor conforme necessário */
+        background-color: #30363d;
       }
 `;
 


### PR DESCRIPTION
## Summary
- show the résumé section by default
- reflect advanced English on the résumé
- adopt a GitHub-dark look for the header and menu
- update overall background to dark gradient

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d5ad6d6c8326a437a3105e2823b8