### PR TITLE
Ajuste de contato e link no ícone

### DIFF
--- a/src/components/Contato/index.js
+++ b/src/components/Contato/index.js
@@ -17,13 +17,26 @@ const Contact = styled.li`
   margin-bottom: 10px;
 `;
 
+const ContactLink = styled.a`
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 export default function Contato() {
   return (
     <Section id="contato">
       <Title>Contato</Title>
       <ContactList>
-        <Contact>Email: <a href="mailto:lk@serrante.com.br">lk@serrante.com.br</a></Contact>
-        <Contact>LinkedIn: <a href="https://www.linkedin.com/in/lukas-de-souza-santos-3a2423183">/in/lukas-de-souza-santos-3a2423183</a></Contact>
+        <Contact>
+          Email: <ContactLink href="mailto:lk@serrante.com.br">lk@serrante.com.br</ContactLink>
+        </Contact>
+        <Contact>
+          LinkedIn: <ContactLink href="https://www.linkedin.com/in/lukas-de-souza-santos-3a2423183">/in/lukas-de-souza-santos-3a2423183</ContactLink>
+        </Contact>
       </ContactList>
     </Section>
   );

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -12,7 +12,7 @@ export default function Header({ onSelect }) {
     return (
         <HeaderContainer>
             <OptionsHeader onSelect={onSelect} />
-            <IconsHeader />
+            <IconsHeader onSelect={onSelect} />
         </HeaderContainer>
     )
 }

--- a/src/components/IconsHeader/index.js
+++ b/src/components/IconsHeader/index.js
@@ -19,10 +19,19 @@ const IconImg = styled.img`
     border-radius: 50%;
 `;
 
-export default function IconsHeader() {
+const Link = styled.a`
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+`;
+export default function IconsHeader({ onSelect }) {
     return (
         <Icons>
-                <Icon><IconImg src={icon} alt=''></IconImg></Icon>
+            <Icon>
+                <Link href="#curriculo" onClick={(e) => { e.preventDefault(); onSelect && onSelect('curriculo'); }}>
+                    <IconImg src={icon} alt='' />
+                </Link>
+            </Icon>
         </Icons>
     )
 }


### PR DESCRIPTION
## Summary
- remove default link coloring in Contact section
- link header icon to the curriculo section

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d663c8e083268870988a0eab13fd