### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/Contato/index.js
+++ b/src/components/Contato/index.js
@@ -3,6 +3,12 @@ import styled from 'styled-components';
 const Section = styled.section`
   padding: 40px 20px;
   color: #fff;
+  max-width: 800px;
+  margin: 0 auto;
+
+  @media (max-width: 600px) {
+    padding: 20px 10px;
+  }
 `;
 
 const Title = styled.h2`

--- a/src/components/Curriculo/index.js
+++ b/src/components/Curriculo/index.js
@@ -3,6 +3,12 @@ import styled from 'styled-components';
 const Section = styled.section`
   padding: 40px 20px;
   color: #fff;
+  max-width: 800px;
+  margin: 0 auto;
+
+  @media (max-width: 600px) {
+    padding: 20px 10px;
+  }
 `;
 
 const Title = styled.h2`

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -6,6 +6,12 @@ const HeaderContainer = styled.header`
     background-color: #0d1117;
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
+    align-items: center;
+
+    @media (max-width: 600px) {
+        padding: 10px 0;
+    }
 `;
 
 export default function Header({ onSelect }) {

--- a/src/components/IconsHeader/index.js
+++ b/src/components/IconsHeader/index.js
@@ -6,6 +6,10 @@ const Icon = styled.li`
     margin-right: 40px;
     width: 25px;
     cursor: pointer;
+
+    @media (max-width: 600px) {
+        margin-right: 20px;
+    }
 `;
 
 const Icons = styled.ul`
@@ -17,6 +21,10 @@ const IconImg = styled.img`
     width: 250%;
     height: 100%;
     border-radius: 50%;
+
+    @media (max-width: 600px) {
+        width: 200%;
+    }
 `;
 
 const Link = styled.a`

--- a/src/components/OptionsHeader/index.js
+++ b/src/components/OptionsHeader/index.js
@@ -2,6 +2,12 @@ import styled from "styled-components";
 
 const Options = styled.ul`
     display: flex;
+    padding: 0;
+
+    @media (max-width: 600px) {
+        flex-direction: column;
+        width: 100%;
+    }
 `;
 
 const Option = styled.li`
@@ -15,6 +21,11 @@ const Option = styled.li`
     padding: 0 5px;
     cursor: pointer;
     min-width: 120px;
+
+    @media (max-width: 600px) {
+        padding: 10px 0;
+        min-width: unset;
+    }
 `;
 
 const Link = styled.a`
@@ -25,6 +36,10 @@ const Link = styled.a`
     display: flex;
     width: 100%;
     height: 150%;
+
+    @media (max-width: 600px) {
+        height: 100%;
+    }
     
     &:hover {
         background-color: #30363d;

--- a/src/components/Projetos/index.js
+++ b/src/components/Projetos/index.js
@@ -3,6 +3,12 @@ import styled from 'styled-components';
 const Section = styled.section`
   padding: 40px 20px;
   color: #fff;
+  max-width: 800px;
+  margin: 0 auto;
+
+  @media (max-width: 600px) {
+    padding: 20px 10px;
+  }
 `;
 
 const Title = styled.h2`

--- a/src/components/SobreMim/index.js
+++ b/src/components/SobreMim/index.js
@@ -3,6 +3,12 @@ import styled from 'styled-components';
 const Section = styled.section`
   padding: 40px 20px;
   color: #fff;
+  max-width: 800px;
+  margin: 0 auto;
+
+  @media (max-width: 600px) {
+    padding: 20px 10px;
+  }
 `;
 
 const Title = styled.h2`


### PR DESCRIPTION
## Summary
- add flexible wrapping header container
- stack navigation options vertically on small screens
- shrink avatar and margin on small screens
- limit section width and padding for smaller viewports

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d94bfbc88326b28db0e61f0c91c8